### PR TITLE
Replaced compile with implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ allprojects {
 2. Add the dependency in your project `build.gradle` file
 ```gradle
 dependencies {
-    compile('me.jahirfiquitiva:Blueprint:{latest version}@aar') {
+    implementation('me.jahirfiquitiva:Blueprint:{latest version}@aar') {
         transitive = true
     }
 }


### PR DESCRIPTION
As compile will be deprecated after 2018, the recommended usage by Android Studio is implementation.

This PR replaces compile, with implementation to prevent compatibility issues.