### PR TITLE
Improve App Bundle File Naming (1/2)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,12 +19,6 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {
-    applicationVariants.all { variant ->
-        variant.outputs.all { output ->
-            outputFileName = defaultConfig.applicationId + "-v${variant.versionName}-${variant.name}.apk"
-        }
-    }
-
     lintOptions {
         abortOnError false
         checkReleaseBuilds true
@@ -44,6 +38,7 @@ android {
         targetSdkVersion Versions.targetSdk
         versionCode MyApp.version
         versionName MyApp.versionName
+        setProperty("archivesBaseName", applicationId + "-" versionName)
         vectorDrawables.useSupportLibrary = true
         proguardFiles 'proguard-android-optimize.txt', 'proguard-rules.pro'
         consumerProguardFiles 'proguard-android-optimize.txt', 'proguard-rules.pro'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,7 +38,7 @@ android {
         targetSdkVersion Versions.targetSdk
         versionCode MyApp.version
         versionName MyApp.versionName
-        setProperty("archivesBaseName", applicationId + "-" versionName)
+        setProperty("archivesBaseName", applicationId + "-" + versionName)
         vectorDrawables.useSupportLibrary = true
         proguardFiles 'proguard-android-optimize.txt', 'proguard-rules.pro'
         consumerProguardFiles 'proguard-android-optimize.txt', 'proguard-rules.pro'


### PR DESCRIPTION
The `archivesBaseName` property supports APK and AAB files alike, resolving Issue #228. See also Pull Request #235.