### PR TITLE
Improve App Bundle File Naming (2/2)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,7 +47,7 @@ android {
         targetSdkVersion Versions.targetSdk
         versionCode Blueprint.version
         versionName Blueprint.versionName
-        setProperty("archivesBaseName", applicationId + "-" versionName)
+        setProperty("archivesBaseName", applicationId + "-" + versionName)
         vectorDrawables.useSupportLibrary = true
         proguardFiles 'proguard-android-optimize.txt', 'proguard-rules.pro'
         consumerProguardFiles 'proguard-android-optimize.txt', 'proguard-rules.pro'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,12 +28,6 @@ android {
         }
     }
 
-    applicationVariants.all { variant ->
-        variant.outputs.all { output ->
-            outputFileName = defaultConfig.applicationId + "-v${variant.versionName}-${variant.name}.apk"
-        }
-    }
-
     lintOptions {
         abortOnError false
         checkReleaseBuilds true
@@ -53,6 +47,7 @@ android {
         targetSdkVersion Versions.targetSdk
         versionCode Blueprint.version
         versionName Blueprint.versionName
+        setProperty("archivesBaseName", applicationId + "-" versionName)
         vectorDrawables.useSupportLibrary = true
         proguardFiles 'proguard-android-optimize.txt', 'proguard-rules.pro'
         consumerProguardFiles 'proguard-android-optimize.txt', 'proguard-rules.pro'


### PR DESCRIPTION
The `archivesBaseName` property supports APK and AAB files alike, resolving Issue #228. See also Pull Request #234.