### PR TITLE
Fix icon request email subject

### DIFF
--- a/library/src/main/kotlin/dev/jahir/blueprint/data/requests/SendIconRequest.kt
+++ b/library/src/main/kotlin/dev/jahir/blueprint/data/requests/SendIconRequest.kt
@@ -292,7 +292,7 @@ object SendIconRequest {
         }
 
         val email = context.string(R.string.email)
-        val subject = context.string(R.string.email_subject)
+        val subject = context.string(R.string.request_title)
         if (!email.hasContent() || !subject.hasContent()) {
             callback?.onRequestError()
             return


### PR DESCRIPTION
### Description
`email_subject` was being used instead of `request_title` for icon request emails. This PR fixes this.