### PR TITLE
Support Pacific Manager response schema & improve error handling in `uploadToRequestManager`

### DIFF
--- a/library/src/main/kotlin/dev/jahir/blueprint/data/models/RequestManagerResponse.kt
+++ b/library/src/main/kotlin/dev/jahir/blueprint/data/models/RequestManagerResponse.kt
@@ -4,4 +4,4 @@ import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-data class RequestManagerResponse(val status: String? = null, val error: String? = null) : Parcelable
+data class RequestManagerResponse(val status: String? = null, val message: String? = null) : Parcelable

--- a/library/src/main/kotlin/dev/jahir/blueprint/ui/activities/BlueprintActivity.kt
+++ b/library/src/main/kotlin/dev/jahir/blueprint/ui/activities/BlueprintActivity.kt
@@ -474,7 +474,13 @@ abstract class BlueprintActivity : FramesActivity(), RequestCallback {
     override fun onRequestError(reason: String?, e: Throwable?) {
         super.onRequestError(reason, e)
         showRequestDialog {
-            message(string(R.string.requests_upload_error, reason))
+            message(
+                if (reason != null) {
+                    string(R.string.requests_upload_error, reason)
+                } else {
+                    string(R.string.requests_upload_error_unknown)
+                }
+            )
         }
     }
 

--- a/library/src/main/res/values/translatable_strings.xml
+++ b/library/src/main/res/values/translatable_strings.xml
@@ -54,6 +54,7 @@
     <string name="icon_shape_square">Square</string>
     <string name="icon_shape_teardrop">Teardrop</string>
     <string name="requests_upload_error">Something went wrong. Error name: “%1$s”.</string>
+    <string name="requests_upload_error_unknown">Something went wrong.</string>
 
     <!-- HELP SECTION -->
     <string-array name="questions">


### PR DESCRIPTION
I’ve discussed and tested this with @justinkruit. Pacific Manager aside, these changes seemed to temporarily make Arctic Manager work again for us, but it stopped functioning the next day. This may have been because we reached the request count limit.