### PR TITLE
Fix market url being opened in browser

### DIFF
--- a/app/src/main/res/values/home_setup.xml
+++ b/app/src/main/res/values/home_setup.xml
@@ -33,17 +33,21 @@
     <string-array name="home_list_titles">
         <item>IconShowcase</item>
         <item>An App</item>
+        <item>An App</item>
     </string-array>
     <string-array name="home_list_descriptions">
         <item>It is the old version of this awesome dashboard</item>
         <item>This is an app</item>
+        <item>This is market url</item>
     </string-array>
     <string-array name="home_list_icons">
+        <item>ic_na_launcher</item>
         <item>ic_na_launcher</item>
         <item>ic_na_launcher</item>
     </string-array>
     <string-array name="home_list_links">
         <item>https://github.com/jahirfiquitiva/Blueprint</item>
         <item>https://play.google.com/store/apps/details?id=com.android.settings</item>
+        <item>market://details?id=com.example.package</item>
     </string-array>
 </resources>


### PR DESCRIPTION
Fixed market url being opened in browser. 

When the url of the market protocol is configured,
```xml
<string-array name="home_list_links">
        <item>market://details?id=com.example.package</item>
</string-array>
```
The following address will open in your browser:
`http://market://details?id=com.example.package`