### PR TITLE
Replace Arctic references with Pacific

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Free, feature-rich, easily customizable Android dashboard for icon packs
 - Support for adaptive icon packs
 - In-app icon request tool
 - Premium Icon Requests (Coming soon!)
-- Support for [Arctic Manager](https://arcticmanager.com/)
+- Support for [Pacific Manager](https://pacificmanager.app/)
 - Apply section with 20 supported launchers. (Other launchers might not support direct apply)
 - Help section, to answer the questions your users have.
 - Support for Zooper templates, Kustom Wallpapers, Widgets, Lockscreens and Komponents.

--- a/app/src/main/res/values/blueprint_setup.xml
+++ b/app/src/main/res/values/blueprint_setup.xml
@@ -61,8 +61,8 @@
 
     <!--
         The API key and base URL for the icon request manager.
-        Currently, only Arctic Manager is supported: https://arcticmanager.com.
+        Currently, only Pacific Manager is supported: https://pacificmanager.app.
     -->
     <string name="request_manager_backend_api_key" translatable="false"></string>
-    <string name="request_manager_base_url" translatable="false">https://arcticmanager.com/</string>
+    <string name="request_manager_base_url" translatable="false">https://pacificmanager.app/</string>
 </resources>

--- a/library/src/main/res/values/blueprint_setup.xml
+++ b/library/src/main/res/values/blueprint_setup.xml
@@ -61,8 +61,8 @@
 
     <!--
         The API key and base URL for the icon request manager.
-        Currently, only Arctic Manager is supported: https://arcticmanager.com.
+        Currently, only Pacific Manager is supported: https://pacificmanager.app.
     -->
     <string name="request_manager_backend_api_key" translatable="false"></string>
-    <string name="request_manager_base_url" translatable="false">https://arcticmanager.com/</string>
+    <string name="request_manager_base_url" translatable="false">https://pacificmanager.app/</string>
 </resources>


### PR DESCRIPTION
Arctic Manager will very soon be deprecated and replaced with Pacific Manager, so any reference to Arctic can be replaced for the next release, making Pacific the standard.