### PR TITLE
Don't crop non-squared icons

### DIFF
--- a/library/src/main/res/layout/item_icon.xml
+++ b/library/src/main/res/layout/item_icon.xml
@@ -5,6 +5,6 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:foreground="?attr/selectableItemBackground"
-    android:scaleType="centerCrop"
+    android:scaleType="fitCenter"
     tools:ignore="ContentDescription,UnusedAttribute"
     tools:srcCompat="@drawable/ic_na_launcher" />

--- a/library/src/main/res/layout/item_icon_with_name.xml
+++ b/library/src/main/res/layout/item_icon_with_name.xml
@@ -12,7 +12,7 @@
         android:id="@+id/icon"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:scaleType="centerCrop"
+        android:scaleType="fitCenter"
         tools:ignore="ContentDescription,UnusedAttribute"
         tools:srcCompat="@drawable/ic_na_launcher" />
 


### PR DESCRIPTION
<!--
Any HTML comment will be stripped when the markdown is rendered, so you don't need to delete them.
-->

### Description
When using non 1:1 icons, the current layout is hard to read as they overlay each-other because of the `centerCrop`.
Changing to `fitCenter` fixes it, as shown in the screenshots below.
Note that for 1:1 icons exchanging centerCrop for fitCenter shouldn't make any difference, so the only icons that will be impacted as those non 1:1.

<img width="3840" height="2160" alt="a" src="https://github.com/user-attachments/assets/0593fcac-85eb-456e-8d73-6e1f87bd0f90" />
<img width="3840" height="2160" alt="b" src="https://github.com/user-attachments/assets/7b3eb2c8-35f9-4d5b-bf5a-018c9d5c7037" />



### Motivation
Projectivy Launcher is a Launcher for Android Tv. It can use 1:1 icons as well as 16:9 icons. 
It recently got [its first Icon Pack](https://github.com/SicMundus86/ProjectivyIconPack), however, the picker is currently not easy to read because of this issue.
