### PR TITLE
Add banner request support

### DIFF
--- a/app/src/main/res/values/blueprint_setup.xml
+++ b/app/src/main/res/values/blueprint_setup.xml
@@ -47,6 +47,15 @@
     -->
     <bool name="includes_adaptive_icons">true</bool>
 
+    <!--
+        Define if your icon pack is dedicated to provide Android Tv banners
+        If so, icons request will send applications banner instead of icon when available.
+        0. Automatically detect if the app is running on a Tv device
+        1. Enforce icons, no matter what is detected
+        2. Enforce banners, no matter what is detected
+    -->
+    <integer name="prefer_banner_for_icon_request">0</integer>
+
     <!-- Icon Pack designer/owner e-mail -->
     <string name="email">someone@email.com</string>
 

--- a/library/src/main/kotlin/dev/jahir/blueprint/data/models/RequestApp.kt
+++ b/library/src/main/kotlin/dev/jahir/blueprint/data/models/RequestApp.kt
@@ -14,9 +14,9 @@ data class RequestApp(val name: String, val packageName: String, val component: 
     var icon: Drawable? = null
         private set
 
-    fun loadIcon(context: Context?) {
+    fun loadIcon(context: Context?, preferBanner: Boolean = false) {
         context ?: return
         if (icon != null) return
-        icon = context.getAppIcon(packageName)
+        icon = context.getAppIcon(packageName, preferBanner)
     }
 }

--- a/library/src/main/kotlin/dev/jahir/blueprint/data/viewmodels/RequestsViewModel.kt
+++ b/library/src/main/kotlin/dev/jahir/blueprint/data/viewmodels/RequestsViewModel.kt
@@ -18,6 +18,7 @@ import dev.jahir.blueprint.extensions.blueprintFormat
 import dev.jahir.blueprint.extensions.clean
 import dev.jahir.blueprint.extensions.drawableRes
 import dev.jahir.blueprint.extensions.getLocalizedName
+import dev.jahir.blueprint.extensions.isRunningOnTv
 import dev.jahir.blueprint.extensions.queryIntentActivitiesCompat
 import dev.jahir.frames.extensions.context.getAppName
 import dev.jahir.frames.extensions.context.integer
@@ -203,7 +204,9 @@ class RequestsViewModel(application: Application) : AndroidViewModel(application
             delay(10)
             val appsToRequest = loadAppsToRequest(debug)
             appsToRequestData.postValue(appsToRequest)
-            appsToRequest.forEach { it.loadIcon(context) }
+            val preferBannerAppSetting = context.integer(R.integer.prefer_banner_for_icon_request, 0)
+            val preferBanner = preferBannerAppSetting == 2 || (preferBannerAppSetting == 0 && context.isRunningOnTv())
+            appsToRequest.forEach { it.loadIcon(context, preferBanner) }
         }
     }
 

--- a/library/src/main/kotlin/dev/jahir/blueprint/extensions/Context.kt
+++ b/library/src/main/kotlin/dev/jahir/blueprint/extensions/Context.kt
@@ -1,7 +1,10 @@
 package dev.jahir.blueprint.extensions
 
 import android.annotation.SuppressLint
+import android.app.UiModeManager
 import android.content.Context
+import android.content.pm.PackageManager
+import android.content.res.Configuration
 import androidx.annotation.DrawableRes
 import dev.jahir.blueprint.R
 import dev.jahir.frames.extensions.resources.lower
@@ -15,6 +18,19 @@ fun Context.drawableRes(name: String): Int =
     } catch (e: Exception) {
         0
     }
+
+fun Context.isRunningOnTv(): Boolean {
+    // Detects if the device is a TV via UiModeManager
+    val uiModeManager = getSystemService(Context.UI_MODE_SERVICE) as UiModeManager
+    val isTvMode = uiModeManager.currentModeType == Configuration.UI_MODE_TYPE_TELEVISION
+
+    // Some TVs might not properly set the UI mode
+    // So we check for the LEANBACK feature and the absence of TOUCHSCREEN
+    val hasTouchscreen = packageManager.hasSystemFeature(PackageManager.FEATURE_TOUCHSCREEN)
+    val hasLeanback = packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK)
+
+    return isTvMode || (hasLeanback && !hasTouchscreen)
+}
 
 internal fun Context.getLocalizedName(packageName: String, defaultName: String): String {
     var appName: String? = null

--- a/library/src/main/res/values/blueprint_setup.xml
+++ b/library/src/main/res/values/blueprint_setup.xml
@@ -47,6 +47,15 @@
     -->
     <bool name="includes_adaptive_icons">false</bool>
 
+    <!--
+        Define if your icon pack is dedicated to provide Android Tv banners
+        If so, icons request will send applications banner instead of icon when available.
+        0. Automatically detect if the app is running on a Tv device
+        1. Enforce icons, no matter what is detected
+        2. Enforce banners, no matter what is detected
+    -->
+    <integer name="prefer_banner_for_icon_request">0</integer>
+
     <!-- Icon Pack designer/owner e-mail -->
     <string name="email">someone@email.com</string>
 


### PR DESCRIPTION
<!--
Any HTML comment will be stripped when the markdown is rendered, so you don't need to delete them.
-->

### Description
Adapts icon request to Tv devices.
This PR adds support for app banners on this screen.
If prefer_banner_for_icon_request is set to :
- 2 : the apps banner will be favored over the apps icon
- 1 : the icons will be used (as before this PR)
- 0 : banner or icon will be chosen depending on the device where the pack is installed

### Motivation
On Tvs, usually, the current icons request feature is not adapted as most Tv Icon Packs will favor banner format.

### Screenshots
<img width="3840" height="2160" alt="w1" src="https://github.com/user-attachments/assets/937293cf-b204-46d2-82a9-7c0f8844bb4f" />
<img width="3840" height="2160" alt="w2" src="https://github.com/user-attachments/assets/325f9242-f87f-4c92-8ef7-82c881b41d03" />
